### PR TITLE
Various fixes

### DIFF
--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -625,8 +625,8 @@ def getMsgLimits() {
             	sendEvent(name:"messagesRemaining", value: "${response.data.remaining}")
             	sendEvent(name:"limitReset", value: "${response.data.reset}")
             	SimpleDateFormat sdf = new SimpleDateFormat("dd MMM YYYY, HH:mm a")
-                epoch = (long) response.data.reset*1000
-                rDate = new Date(epoch)
+                def epoch = (long) response.data.reset*1000
+                def rDate = new Date(epoch)
                 sendEvent(name:"limitResetDate", value: sdf.format(rDate))
                 sendEvent(name:"limitLastUpdated", value: sdf.format(new Date()))
             }

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -461,7 +461,7 @@ def deviceNotification(message) {
     // New Retry and Expire Code
     if (priority == "2") {
         // Emergency retry interval
-        if((matcher = message =~ /((\©|\[EM.RETRY=)(.*?)(\©|\]))/ )){
+        if((matcher = message =~ /((\©|\[EM.RETRY=)(\d+)(\©|\]))/ )){
             message = message.minus("${matcher[0][1]}")
             message = message.trim()
             customRetry = matcher[0][3]
@@ -473,7 +473,7 @@ def deviceNotification(message) {
         }
 
         // Emergency message expiration
-        if((matcher = message =~ /((\™|\[EM.EXPIRE=)(.*?)(\™|\]))/ )){
+        if((matcher = message =~ /((\™|\[EM.EXPIRE=)(\d+)(\™|\]))/ )){
             message = message.minus("${matcher[0][1]}")
             message = message.trim()
             customExpire = matcher[0][3]

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -165,15 +165,17 @@ def initialize() {
 }
 
 private boolean keyFormatIsValid() {
-    if (apiKey?.matches('[A-Za-z0-9]{30}') && userKey?.matches('[A-Za-z0-9]{30}')) {                                                              
-        return true                                                                                                                               
-    }                                                                                                                                             
+    if (apiKey?.matches('[A-Za-z0-9]{30}') && userKey?.matches('[A-Za-z0-9]{30}')) {
+        return true
+    }
 
-    if (apiKey != null && userKey != null) {                                                                                                  
+    // Avoid logging a warning if the keys are not set (device page UI renders before device context is available).
+    if (apiKey != null && userKey != null) {
         log.warn "keyFormatIsValid() - API key '${apiKey}' or USER key '${userKey}' is not properly formatted!"
-    }                                                                                                                                         
-    return false                                                                                                                              
-}                                                                                                                                                 
+    }
+
+    return false
+}
 
 // Check if keys have changed and handle invalidation of all caches if they have
 private boolean checkAndHandleKeyChanges() {
@@ -617,7 +619,7 @@ def deviceNotification(message) {
 
 def getMsgLimits() {
     if (logEnable) log.debug "Sending GET request: https://api.pushover.net/1/apps/limits.json?token=...${apiKey?.substring(25,30)}"
-   
+
 	def uri = "https://api.pushover.net/1/apps/limits.json?token=${apiKey}"
 
     try {

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -166,16 +166,7 @@ def initialize() {
 }
 
 private boolean keyFormatIsValid() {
-    if (apiKey?.matches('[A-Za-z0-9]{30}') && userKey?.matches('[A-Za-z0-9]{30}')) {
-        return true
-    }
-
-    // Avoid logging a warning if the keys are not set (device page UI renders before device context is available).
-    if (apiKey != null && userKey != null) {
-        log.warn "keyFormatIsValid() - API key '${apiKey}' or USER key '${userKey}' is not properly formatted!"
-    }
-
-    return false
+    return apiKey?.matches('[A-Za-z0-9]{30}') && userKey?.matches('[A-Za-z0-9]{30}')
 }
 
 // Check if keys have changed and handle invalidation of all caches if they have

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -415,7 +415,6 @@ def deviceNotification(message) {
         customDevice = customDevice.toLowerCase()
     }
     if(customDevice){ deviceName = customDevice}
-    if (logEnable && device != null) log.debug "Pushover processed device (${device}): " + message
 
     // URL
     if((matcher = message =~ /((\§|\[URL=)(.*?)(\§|\]))/ )){

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -275,7 +275,7 @@ def getSoundOptions() {
                 }
                 else {
                     if (logEnable) log.debug "Notification List Generated: ${response.data.sounds}"
-                    mySounds = response.data.sounds
+                    def mySounds = response.data.sounds
                     mySounds.each {eachSound->
                     myOptions << ["${eachSound.key}":"${eachSound.value}"]
                     }
@@ -446,12 +446,12 @@ def deviceNotification(message) {
 
     // Retrieve image
     if (imageUrl) {
-        log.debug "Getting Notification Image"
+        if (logEnable) log.debug "Getting Notification Image"
         try {
             httpGet("${imageUrl}")  //modify as needed for authentication header
             { response ->
-                imageData = response.data
-                log.debug "Notification Image Received (${imageData.available()})"
+                def imageData = response.data
+                if (logEnable) log.debug "Notification Image Received (${imageData.available()})"
             }
         } catch (Exception e) {
             log.warn "Error retrieving notification image: ${e.message}"

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -465,7 +465,6 @@ def deviceNotification(message) {
     if (logEnable && imageUrl != null) log.debug "Pushover processed image (${imageUrl}): " + message
 
     // Retrieve image
-    def imageData
     if (imageUrl) {
         if (logEnable) log.debug "Getting Notification Image"
         try {

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -415,7 +415,7 @@ def deviceNotification(message) {
         customDevice = customDevice.toLowerCase()
     }
     if(customDevice){ deviceName = customDevice}
-    if (logEnable && device != null) log.debug "Pushover processed device (${deviceName}): " + message
+    if (logEnable && deviceName != null) log.debug "Pushover processed device (${deviceName}): " + message
 
     // URL
     if((matcher = message =~ /((\§|\[URL=)(.*?)(\§|\]))/ )){

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -616,7 +616,10 @@ def getMsgLimits() {
 	
     try {
         httpGet(uri) { response ->
-            if (response.status) {
+            if(response.status != 200) {
+                log.error "Received HTTP error ${response.status}. Check your keys!"
+            }
+            else {
             	if (logEnable) log.debug "${response.data}"
             	sendEvent(name:"messageLimit", value: "${response.data.limit}")
             	sendEvent(name:"messagesRemaining", value: "${response.data.remaining}")
@@ -626,7 +629,7 @@ def getMsgLimits() {
                 rDate = new Date(epoch)
                 sendEvent(name:"limitResetDate", value: sdf.format(rDate))
                 sendEvent(name:"limitLastUpdated", value: sdf.format(now()))
-             }
+            }
         }
     } catch (Exception e) {
         log.warn "Error retrieving message limits failed: ${e.message}"

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -338,9 +338,10 @@ def deviceNotification(message) {
     def customTTL = null
     def imageData = null
     def html = "0"
+    def rawMessage = message
     
     if (logEnable){
-        log.debug "Pushover driver raw message: " + message
+        log.debug "Pushover driver raw message: " + rawMessage
     }
 
     // Message priority
@@ -607,7 +608,7 @@ def deviceNotification(message) {
                 }
                 else {
                     if (logEnable) log.debug "Msg sent to Pushover server"
-                    sendEvent(name:"notificationText", value: message, descriptionText:"Msg sent to Pushover server", isStateChange: true)
+                    sendEvent(name:"notificationText", value: rawMessage, descriptionText:"Msg sent to Pushover server", isStateChange: true)
                 }
             }
         }

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -130,7 +130,7 @@ def updated() {
         log.info "Enabling Debug Logging for 30 minutes"
         runIn(1800,logsOff)
     } else {
-        unschedule(logsoff)
+        unschedule(logsOff)
     }
 
     if (testingEnable) {

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -610,7 +610,7 @@ def deviceNotification(message) {
 }
 
 def getMsgLimits() {
-    if (logEnable) log.debug "Sending GET request: https://api.pushover.net/1/apps/limits.json?token=...${state.lastApiKey.substring(25,30)}"
+    if (logEnable) log.debug "Sending GET request: https://api.pushover.net/1/apps/limits.json?token=...${state.lastApiKey?.substring(25,30)}"
    
 	uri = "https://api.pushover.net/1/apps/limits.json?token=${state.lastApiKey}"
 	

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -162,14 +162,15 @@ def initialize() {
 }
 
 private boolean keyFormatIsValid() {
-    if (apiKey?.matches('[A-Za-z0-9]{30}') && userKey?.matches('[A-Za-z0-9]{30}')) {
-        return true
-    }
-    else {
+    if (apiKey?.matches('[A-Za-z0-9]{30}') && userKey?.matches('[A-Za-z0-9]{30}')) {                                                              
+        return true                                                                                                                               
+    }                                                                                                                                             
+
+    if (apiKey != null && userKey != null) {                                                                                                  
         log.warn "keyFormatIsValid() - API key '${apiKey}' or USER key '${userKey}' is not properly formatted!"
-        return false
-    }
-}
+    }                                                                                                                                         
+    return false                                                                                                                              
+}                                                                                                                                                 
 
 // Check if keys have changed and handle invalidation of all caches if they have
 private boolean checkAndHandleKeyChanges() {

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -611,9 +611,10 @@ def deviceNotification(message) {
                 }
             }
         }
-        catch (Exception e) {
-            log.error "deviceNotification() - PushOver Server Returned: ${e}"
-	    }
+        catch (groovyx.net.http.HttpResponseException e) {
+            log.error "deviceNotification() - PushOver Server Returned: ${e.message}"
+            log.error "deviceNotification() - Response body: ${e.response?.data.errors}"
+        }
     }
     else {
         log.error "deviceNotification() - API key '${apiKey}' or User key '${userKey}' is not properly formatted!"

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -611,9 +611,9 @@ def deviceNotification(message) {
 }
 
 def getMsgLimits() {
-    if (logEnable) log.debug "Sending GET request: https://api.pushover.net/1/apps/limits.json?token=...${state.lastApiKey?.substring(25,30)}"
+    if (logEnable) log.debug "Sending GET request: https://api.pushover.net/1/apps/limits.json?token=...${apiKey?.substring(25,30)}"
    
-	def uri = "https://api.pushover.net/1/apps/limits.json?token=${state.lastApiKey}"
+	def uri = "https://api.pushover.net/1/apps/limits.json?token=${apiKey}"
 	
     try {
         httpGet(uri) { response ->

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -28,7 +28,7 @@
 *       2026-01-26 Dan Ogorchock         Added "ALL" to list of Pushover Devices, since there is no way to unselect a device once selected
 *       2026-02-01 @hubitrep             Call sendEvent() when message is sent to Pushover, allowing other automations to pick it up from this device.
 *       2026-02-02 Dan Ogorchock         Minor code cleanup and logic improvements
-*       2026-02-03 @hubitrep             Various minor bug fixes
+*       2026-02-03 @hubitrep             Various minor code fixes
 *
 *   Inspired by original work for SmartThings by: Zachary Priddy, https://zpriddy.com, me@zpriddy.com
 *

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -445,12 +445,13 @@ def deviceNotification(message) {
     if (logEnable && imageUrl != null) log.debug "Pushover processed image (${imageUrl}): " + message
 
     // Retrieve image
+    def imageData
     if (imageUrl) {
         if (logEnable) log.debug "Getting Notification Image"
         try {
             httpGet("${imageUrl}")  //modify as needed for authentication header
             { response ->
-                def imageData = response.data
+                imageData = response.data
                 if (logEnable) log.debug "Notification Image Received (${imageData.available()})"
             }
         } catch (Exception e) {

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -622,6 +622,7 @@ def deviceNotification(message) {
 }
 
 def getMsgLimits() {
+    
     if (keyFormatIsValid()) {
  
         if (logEnable) log.debug "getMsgLimits() - Sending GET request: https://api.pushover.net/1/apps/limits.json?token=...${apiKey.substring(25,30)}"

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -612,7 +612,7 @@ def deviceNotification(message) {
 def getMsgLimits() {
     if (logEnable) log.debug "Sending GET request: https://api.pushover.net/1/apps/limits.json?token=...${state.lastApiKey?.substring(25,30)}"
    
-	uri = "https://api.pushover.net/1/apps/limits.json?token=${state.lastApiKey}"
+	def uri = "https://api.pushover.net/1/apps/limits.json?token=${state.lastApiKey}"
 	
     try {
         httpGet(uri) { response ->
@@ -628,7 +628,7 @@ def getMsgLimits() {
                 epoch = (long) response.data.reset*1000
                 rDate = new Date(epoch)
                 sendEvent(name:"limitResetDate", value: sdf.format(rDate))
-                sendEvent(name:"limitLastUpdated", value: sdf.format(now()))
+                sendEvent(name:"limitLastUpdated", value: sdf.format(new Date()))
             }
         }
     } catch (Exception e) {

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -27,6 +27,7 @@
 *       2026-01-21 Dan Ogorchock         Minor code cleanup, update version number, minor bug fixes, added usage to the comments section
 *       2026-01-26 Dan Ogorchock         Added "ALL" to list of Pushover Devices, since there is no way to unselect a device once selected
 *       2026-02-01 @hubitrep             Call sendEvent() when message is sent to Pushover, allowing other automations to pick it up from this device.
+*       2026-02-02 @hubitrep             Various minor bug fixes
 *
 *   Inspired by original work for SmartThings by: Zachary Priddy, https://zpriddy.com, me@zpriddy.com
 *
@@ -69,7 +70,7 @@
 
 import java.text.SimpleDateFormat
 
-def version() {return "v1.0.20260201"}
+def version() {return "v1.0.20260202"}
 
 metadata {
     definition (name: "Pushover", namespace: "ogiewon", author: "Dan Ogorchock", importUrl: "https://raw.githubusercontent.com/ogiewon/Hubitat/master/Drivers/pushover-notifications.src/pushover-notifications.groovy", singleThreaded:true) {

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -283,7 +283,7 @@ def getSoundOptions() {
             }
         }
         catch (Exception e) {
-            log.error "PushOver Server Returned: ${e}"
+            log.error "Error retrieving sound options - PushOver Server Returned: ${e}"
         }
     }
     else {
@@ -415,6 +415,7 @@ def deviceNotification(message) {
         customDevice = customDevice.toLowerCase()
     }
     if(customDevice){ deviceName = customDevice}
+    if (logEnable && device != null) log.debug "Pushover processed device (${deviceName}): " + message
 
     // URL
     if((matcher = message =~ /((\§|\[URL=)(.*?)(\§|\]))/ )){
@@ -446,10 +447,14 @@ def deviceNotification(message) {
     // Retrieve image
     if (imageUrl) {
         log.debug "Getting Notification Image"
-        httpGet("${imageUrl}")  //modify as needed for authentication header
-        { response ->
-            imageData = response.data
-            log.debug "Notification Image Received (${imageData.available()})"
+        try {
+            httpGet("${imageUrl}")  //modify as needed for authentication header
+            { response ->
+                imageData = response.data
+                log.debug "Notification Image Received (${imageData.available()})"
+            }
+        } catch (Exception e) {
+            log.warn "Error retrieving notification image: ${e.message}"
         }
     }
 
@@ -624,6 +629,6 @@ def getMsgLimits() {
              }
         }
     } catch (Exception e) {
-        log.warn "Call to on failed: ${e.message}"
+        log.warn "Error retrieving message limits failed: ${e.message}"
     }
 }


### PR DESCRIPTION
- removed log from keyFormatIsValid() - all callers log the error.  Avoids occasional erroneous warning in app config UI render context (sometimes attributed to dev:null...).
- wrapped notification image http fetch in try/catch
- EM.RETRY and EM.EXPIRE match integer values only (same as SELFDESTRUCT)
- use raw message for event (so it can be reused)
- better logging of Pushover API errors as per API docs - describes explicitly what's wrong with the payload (see screenshot below for an example) 
- getMsgLimits(): fix truthiness issue, var scope & date format

<img width="1083" height="48" alt="image" src="https://github.com/user-attachments/assets/34c9bfcb-1a51-4350-a607-df82e4e80c36" />

Note that there are many commits in this PR that were merged out with your own last commit.