### PR TITLE
Acknowledgement polling & callback feature

### DIFF
--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -29,7 +29,7 @@
 *       2026-02-01 @hubitrep             Call sendEvent() when message is sent to Pushover, allowing other automations to pick it up from this device.
 *       2026-02-02 Dan Ogorchock         Minor code cleanup and logic improvements
 *       2026-02-03 @hubitrep             Various minor code fixes
-*       2026-02-04 @hubitrep             Added Emergency acknowledgement receipt polling
+*       2026-02-XX @hubitrep             Added Emergency acknowledgement receipt polling
 *
 *   Inspired by original work for SmartThings by: Zachary Priddy, https://zpriddy.com, me@zpriddy.com
 *
@@ -55,8 +55,8 @@
 *      [IMAGE=imageurl] -- url and path to replacement notification icon (equivalent to ¨imageurl¨)
 *      [EM.RETRY=x] -- for emergency priority, how often does it get "sent" in x seconds (equivalent to ©retryinterval©)
 *      [EM.EXPIRE=y] -- for emergency priority, when should repeating stop in y seconds, even if not acknowledged (equivalent to ™expirelength™)
-*      [SELFDESTRUCT=z] -- auto delete message in z seconds (no equivalent)
 *      [EM.POLL=n] -- for emergency priority, poll for acknowledgement every n seconds (default: 30, no equivalent)
+*      [SELFDESTRUCT=z] -- auto delete message in z seconds (no equivalent)
 *      \n -- line breaks in HTML messages. can also use ≤br≥ using the custom HTML characters feature below.
 *
 *      Set the custom HTML open and close characters to use additional HTML formatting. The default character is ≤ and ≥ (equivalent to [OPEN] and [CLOSE])
@@ -73,7 +73,7 @@
 
 import java.text.SimpleDateFormat
 
-def version() {return "v1.0.20260204"}
+def version() {return "v1.0.202602XX"}
 
 metadata {
     definition (name: "Pushover", namespace: "ogiewon", author: "Dan Ogorchock", importUrl: "https://raw.githubusercontent.com/ogiewon/Hubitat/master/Drivers/pushover-notifications.src/pushover-notifications.groovy", singleThreaded:true) {

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -364,7 +364,7 @@ def deviceNotification(message) {
     def imageData = null
     def html = "0"
     def rawMessage = message
-    
+
     if (logEnable) log.debug "Pushover driver raw message: ${rawMessage}"
 
     // Message priority
@@ -510,27 +510,24 @@ def deviceNotification(message) {
 
         // Emergency acknowledgement poll interval override
         if((matcher = EM_POLL_PATTERN.matcher(message)).find()){
-            message = message.minus("${matcher[0][1]}")
-            message = message.trim()
+            message = message.minus("${matcher[0][1]}").trim()
             customEmPollInterval = matcher[0][2]
-        }
-        if(customEmPollInterval){
-            emPollInterval = customEmPollInterval.toInteger()
-            if (emPollInterval > 0 && emPollInterval < 30){ emPollInterval = 30 }
-            if (logEnable) log.debug "Pushover processed emergency poll interval (${emPollInterval}): " + message
+            if(customEmPollInterval){
+                emPollInterval = customEmPollInterval.toInteger()
+                if (emPollInterval > 0 && emPollInterval < 30){ emPollInterval = 30 }
+                if (logEnable) log.debug "Pushover processed emergency poll interval (${emPollInterval}): " + message
+            }
         }
 
         // Emergency acknowledgement callback URL override
         if((matcher = EM_CALLBACK_PATTERN.matcher(message)).find()){
-            message = message.minus("${matcher[0][1]}")
-            message = message.trim()
+            message = message.minus("${matcher[0][1]}").trim()
             customEmCallbackUrl = matcher[0][2]
+            if(customEmCallbackUrl){
+                emCallbackUrl = customEmCallbackUrl
+                if (logEnable) log.debug "Pushover processed emergency callback URL (${emCallbackUrl}): " + message
+            }
         }
-        if(customEmCallbackUrl){
-            emCallbackUrl = customEmCallbackUrl
-            if (logEnable) log.debug "Pushover processed emergency callback URL (${emCallbackUrl}): " + message
-        }
-
     }
 
     // TTL Time to Live
@@ -561,7 +558,7 @@ def deviceNotification(message) {
 
     // OPTIMIZATION: Use StringBuilder for HTTP body construction
     def postBodyBuilder = new StringBuilder("""----d29vZHNieQ==\r\nContent-Disposition: form-data; name="user"\r\n\r\n$userKey\r\n----d29vZHNieQ==\r\nContent-Disposition: form-data; name="token"\r\n\r\n$apiKey\r\n----d29vZHNieQ==\r\n""")
-    
+
     if (title) {
         postBodyBuilder.append("""Content-Disposition: form-data; name="title"\r\n\r\n${title}\r\n----d29vZHNieQ==\r\n""")
     }
@@ -597,9 +594,9 @@ def deviceNotification(message) {
         postBodyBuilder.append("""Content-Disposition: form-data; name="html"\r\n\r\n${html}\r\n----d29vZHNieQ==\r\n""")
     }
     if (message == "") message = Character.toString((char) 128)
-    
+
     postBodyBuilder.append("""Content-Disposition: form-data; name="message"\r\n\r\n${message}\r\n----d29vZHNieQ==\r\n""")
-    
+
     if (imageData) {
         postBodyBuilder.append("""Content-Disposition: form-data; name="attachment"; filename="image.jpg"\r\nContent-Type: image/jpeg\r\n\r\n""")
     } else {
@@ -616,14 +613,14 @@ def deviceNotification(message) {
 
     ByteArrayOutputStream postBodyOutputStream = new ByteArrayOutputStream()
     postBodyOutputStream.write(postBodyTopArr)
-    
+
     if (imageData) {
         def bSize = imageData.available()
         byte[] imageArr = new byte[bSize]
         imageData.read(imageArr, 0, bSize)
         postBodyOutputStream.write(imageArr)
     }
-    
+
     postBodyOutputStream.write(postBodyBottomArr)
     byte[] postBody = postBodyOutputStream.toByteArray()
 
@@ -633,7 +630,7 @@ def deviceNotification(message) {
     	uri: "https://api.pushover.net/1/messages.json",
     	body: postBody
     ]
-    
+
     if (keyFormatIsValid()) {
         try {
             httpPost(params) { response ->
@@ -675,9 +672,9 @@ def deviceNotification(message) {
 }
 
 def getMsgLimits() {
-    
+
     if (keyFormatIsValid()) {
- 
+
         if (logEnable) log.debug "getMsgLimits() - Sending GET request: https://api.pushover.net/1/apps/limits.json?token=...${apiKey.substring(25,30)}"
 
 	    uri = "https://api.pushover.net/1/apps/limits.json?token=${apiKey}"

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -228,12 +228,13 @@ def getDeviceOptions(){
                 }
             }
         }
-        catch (Exception e) {
-            log.error "PushOver Server Returned: ${e}"
+        catch (groovyx.net.http.HttpResponseException e) {
+            log.error "getDeviceOptions() - PushOver Server Returned: ${e.message}"
+            log.error "getDeviceOptions() - Response body: ${e.response?.data?.errors}"
         }
     }
     else {
-        log.error "GetDeviceOptions() - API key '${apiKey}' or User key '${userKey}' is not properly formatted!"
+        log.error "getDeviceOptions() - API key '${apiKey}' or User key '${userKey}' is not properly formatted!"
     }
 
     return deviceOptions
@@ -284,12 +285,13 @@ def getSoundOptions() {
                 }
             }
         }
-        catch (Exception e) {
-            log.error "Error retrieving sound options - PushOver Server Returned: ${e}"
+        catch (groovyx.net.http.HttpResponseException e) {
+            log.error "getSoundOptions() - PushOver Server Returned: ${e.message}"
+            log.error "getSoundOptions() - Response body: ${e.response?.data?.errors}"
         }
     }
     else {
-        log.error "GetSoundsOptions() - API key '${apiKey}' or User key '${userKey}' is not properly formatted!"
+        log.error "getSoundOptions() - API key '${apiKey}' or User key '${userKey}' is not properly formatted!"
     }
 
     return myOptions
@@ -682,8 +684,9 @@ def getMsgLimits() {
                         sendEvent(name:"limitLastUpdated", value: sdf.format(new Date()))
                     }
                 }
-        } catch (Exception e) {
-            log.error "getMsgLimits() - PushOver Server Returned: ${e}"
+        } catch (groovyx.net.http.HttpResponseException e) {
+            log.error "getMsgLimits() - PushOver Server Returned: ${e.message}"
+            log.error "getMsgLimits() - Response body: ${e.response?.data?.errors}"
         }
     }
     else {
@@ -734,8 +737,9 @@ def checkEmergencyReceipt() {
             if (logEnable) log.debug "Emergency not yet acknowledged, polling again in ${pollInterval}s"
             runIn(pollInterval, "checkEmergencyReceipt")
         }
-    } catch (Exception e) {
-        log.error "checkEmergencyReceipt() - PushOver Server Returned: ${e}"
+    } catch (groovyx.net.http.HttpResponseException e) {
+        log.error "checkEmergencyReceipt() - PushOver Server Returned: ${e.message}"
+        log.error "checkEmergencyReceipt() - Response body: ${e.response?.data?.errors}"
         state.emergencyReceipt = null
         unschedule("checkEmergencyReceipt")
     }

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -633,6 +633,10 @@ def deviceNotification(message) {
                         def pollInterval = emPollInterval != null ? emPollInterval.toInteger() : 0
                         if (pollInterval > 0) {
                             if (pollInterval < 30) pollInterval = 30
+                            if (state.emergencyReceipt) {
+                                log.warn "New Emergency message sent while still polling receipt ${state.emergencyReceipt} — replacing"
+                                unschedule("checkEmergencyReceipt")
+                            }
                             state.emergencyReceipt = response.data.receipt
                             if (logEnable) log.debug "Emergency receipt: ${response.data.receipt}, polling every ${pollInterval}s"
                             sendEvent(name:"emergencyAck", value: "pending", descriptionText:"Emergency message sent, awaiting acknowledgement", isStateChange: true)

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -163,13 +163,12 @@ def initialize() {
     atomicState.cachedDeviceOptions = null
     atomicState.cachedSoundOptions = null
 
-    //  Needs more input cleansing.
-    if (htmlOpen == null || htmlClose == null
-        || htmlOpen == '' || htmlClose == ''
-        || htmlOpen =~ /[\s\[\]\\]/ || htmlClose =~ /[\s\[\]\\]/
-    ) {
-    	htmlOpen = "≤"
-    	htmlClose = "≥"
+    // Reset invalid HTML open/close characters to defaults
+    if (htmlOpen == null || htmlOpen == '' || htmlOpen =~ /[\s\[\]\\]/) {
+        device.updateSetting("htmlOpen", [value: "≤", type: "text"])
+    }
+    if (htmlClose == null || htmlClose == '' || htmlClose =~ /[\s\[\]\\]/) {
+        device.updateSetting("htmlClose", [value: "≥", type: "text"])
     }
 }
 

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -78,7 +78,7 @@ import java.text.SimpleDateFormat
 import groovyx.net.http.HttpResponseException
 import groovy.transform.Field
 
-def version() {return "v1.0.20260207"}
+def version() {return "v1.0.202602XX"}
 
 metadata {
     definition (name: "Pushover", namespace: "ogiewon", author: "Dan Ogorchock", importUrl: "https://raw.githubusercontent.com/ogiewon/Hubitat/master/Drivers/pushover-notifications.src/pushover-notifications.groovy", singleThreaded:true) {

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -72,6 +72,7 @@
 */
 
 import java.text.SimpleDateFormat
+import groovyx.net.http.HttpResponseException
 
 def version() {return "v1.0.202602XX"}
 
@@ -228,7 +229,7 @@ def getDeviceOptions(){
                 }
             }
         }
-        catch (groovyx.net.http.HttpResponseException e) {
+        catch (HttpResponseException e) {
             log.error "getDeviceOptions() - PushOver Server Returned: ${e.message}"
             log.error "getDeviceOptions() - Response body: ${e.response?.data?.errors}"
         }
@@ -285,7 +286,7 @@ def getSoundOptions() {
                 }
             }
         }
-        catch (groovyx.net.http.HttpResponseException e) {
+        catch (HttpResponseException e) {
             log.error "getSoundOptions() - PushOver Server Returned: ${e.message}"
             log.error "getSoundOptions() - Response body: ${e.response?.data?.errors}"
         }
@@ -648,7 +649,7 @@ def deviceNotification(message) {
                 }
             }
         }
-        catch (groovyx.net.http.HttpResponseException e) {
+        catch (HttpResponseException e) {
             log.error "deviceNotification() - PushOver Server Returned: ${e.message}"
             log.error "deviceNotification() - Response body: ${e.response?.data.errors}"
         }
@@ -684,7 +685,7 @@ def getMsgLimits() {
                         sendEvent(name:"limitLastUpdated", value: sdf.format(new Date()))
                     }
                 }
-        } catch (groovyx.net.http.HttpResponseException e) {
+        } catch (HttpResponseException e) {
             log.error "getMsgLimits() - PushOver Server Returned: ${e.message}"
             log.error "getMsgLimits() - Response body: ${e.response?.data?.errors}"
         }
@@ -737,7 +738,7 @@ def checkEmergencyReceipt() {
             if (logEnable) log.debug "Emergency not yet acknowledged, polling again in ${pollInterval}s"
             runIn(pollInterval, "checkEmergencyReceipt")
         }
-    } catch (groovyx.net.http.HttpResponseException e) {
+    } catch (HttpResponseException e) {
         log.error "checkEmergencyReceipt() - PushOver Server Returned: ${e.message}"
         log.error "checkEmergencyReceipt() - Response body: ${e.response?.data?.errors}"
         state.emergencyReceipt = null

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -581,17 +581,28 @@ def deviceNotification(message) {
     if (priority) {
         postBodyBuilder.append("""Content-Disposition: form-data; name="priority"\r\n\r\n${priority}\r\n----d29vZHNieQ==\r\n""")
     }
-    if (retry) {
-        postBodyBuilder.append("""Content-Disposition: form-data; name="retry"\r\n\r\n${retry}\r\n----d29vZHNieQ==\r\n""")
-    }
-    if (expire) {
-        postBodyBuilder.append("""Content-Disposition: form-data; name="expire"\r\n\r\n${expire}\r\n----d29vZHNieQ==\r\n""")
-    }
-    if (emCallbackUrl) {
-        postBodyBuilder.append("""Content-Disposition: form-data; name="callback"\r\n\r\n${emCallbackUrl}\r\n----d29vZHNieQ==\r\n""")
-    }
-    if (ttl) {
-        postBodyBuilder.append("""Content-Disposition: form-data; name="ttl"\r\n\r\n${ttl}\r\n----d29vZHNieQ==\r\n""")
+    // Emergency-only parameters: retry, expire, callback
+    if (priority == "2") {
+        if (retry) {
+            postBodyBuilder.append("""Content-Disposition: form-data; name="retry"\r\n\r\n${retry}\r\n----d29vZHNieQ==\r\n""")
+        }
+        if (expire) {
+            postBodyBuilder.append("""Content-Disposition: form-data; name="expire"\r\n\r\n${expire}\r\n----d29vZHNieQ==\r\n""")
+        }
+        if (emCallbackUrl) {
+            postBodyBuilder.append("""Content-Disposition: form-data; name="callback"\r\n\r\n${emCallbackUrl}\r\n----d29vZHNieQ==\r\n""")
+        }
+        if (ttl) {
+            log.warn "deviceNotification() - TTL/SELFDESTRUCT ignored for Emergency priority messages"
+        }
+    } else {
+        // Non-emergency parameter: ttl
+        if (ttl) {
+            postBodyBuilder.append("""Content-Disposition: form-data; name="ttl"\r\n\r\n${ttl}\r\n----d29vZHNieQ==\r\n""")
+        }
+        if (emCallbackUrl) {
+            log.warn "deviceNotification() - Callback URL ignored for non-Emergency priority messages"
+        }
     }
     if (html == "1") {
         postBodyBuilder.append("""Content-Disposition: form-data; name="html"\r\n\r\n${html}\r\n----d29vZHNieQ==\r\n""")

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -230,8 +230,8 @@ def getDeviceOptions(){
 
     if (keyFormatIsValid()) {
         def postBody = [
-            token: "$apiKey",
-            user: "$userKey",
+            token: apiKey,
+            user: userKey,
             device: ""
         ]
 

--- a/Drivers/pushover-notifications.src/pushover-notifications.groovy
+++ b/Drivers/pushover-notifications.src/pushover-notifications.groovy
@@ -30,7 +30,7 @@
 *       2026-02-02 Dan Ogorchock         Minor code cleanup and logic improvements
 *       2026-02-03 @hubitrep             Various minor code fixes
 *       2026-02-07 Dan Ogorchock         Code optimized: Pre-compiled regex patterns for faster message processing, StringBuilder for HTTP body construction, Optimized string operations, Reduced redundant method calls
-*       2026-02-XX @hubitrep             Added Emergency acknowledgement receipt polling and callback URL features
+*       2026-03-04 @hubitrep             Added Emergency acknowledgement receipt polling and callback URL features
 *
 *   Inspired by original work for SmartThings by: Zachary Priddy, https://zpriddy.com, me@zpriddy.com
 *
@@ -78,7 +78,7 @@ import java.text.SimpleDateFormat
 import groovyx.net.http.HttpResponseException
 import groovy.transform.Field
 
-def version() {return "v1.0.202602XX"}
+def version() {return "v1.0.20260304"}
 
 metadata {
     definition (name: "Pushover", namespace: "ogiewon", author: "Dan Ogorchock", importUrl: "https://raw.githubusercontent.com/ogiewon/Hubitat/master/Drivers/pushover-notifications.src/pushover-notifications.groovy", singleThreaded:true) {


### PR DESCRIPTION
New Pushover API feature supported: emergency message acknowledgement via both polling and callback URL.

Note that this driver's acknowledgement polling feature is limited compared to what the Pushover API supports (a specific receipt can be tracked per message, allowing concurrent emergency messages to be tracked independently).  I investigated supporting the full feature but that complexifies the driver significantly and the use-case is not obvious to me.  The callback URL is managed Pushover-side and allows specific URLs  per message, as a better option IMO.  A user that requires polling for multiple concurrent emergency messages for their use-case might instantiate multiple devices with this driver instead.

A few other minor changes made along the way.

Thank you for your consideration.
